### PR TITLE
draft-implement-battery-voltage-reading

### DIFF
--- a/Teensy/.vscode/settings.json
+++ b/Teensy/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.configureOnOpen": true
+}

--- a/Teensy/.vscode/settings.json
+++ b/Teensy/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "cmake.configureOnOpen": true
-}

--- a/Teensy/src/gpio/gpio.cpp
+++ b/Teensy/src/gpio/gpio.cpp
@@ -96,19 +96,16 @@ static GyroData_s gpio_getGyro()
 }
 
 // defining resistors for voltage divider
-constexpr float BATTERY_SCALER = (4000.0f + 1000.0f ) / 1000.0f;
-// the ADC analog Input is returned in 10 bit format 
+constexpr float BATTERY_SCALAR = (4000.0f + 1000.0f ) / 1000.0f;
+// the ADC analog input is returned in 10 bit format 
 #define ADC_MAX_VALUE 1023
 // the ADC can only handle 3.3V
 #define ADC_MAX_VOLTAGE 3.3
 static daq_BatteryV_t gpio_getVBat()
 {
-    // A voltage divider should be scaling down the voltage from 12V to 2.4 V before this
-    // refer to https://www.instructables.com/Voltage-Measurement-Using-Arduino/ for how this formula works
+    float batteryAnalogIn = analogRead(BATTERY_SENSOR_PIN);
     // the formula for 2 resistors connected in series, forming the voltage divider is: V1 = Vm * (R2/(R1+R2))
-
-    float batteryAnalogIn = BATTERY_SENSOR_PIN;
-    float batteryVoltage_dV = ((batteryAnalogIn / ADC_MAX_VALUE) * ADC_MAX_VOLTAGE) * BATTERY_SCALER;
+    float batteryVoltage_dV = ((batteryAnalogIn / ADC_MAX_VALUE) * ADC_MAX_VOLTAGE) * BATTERY_SCALAR;
     
     return batteryVoltage_dV;
 }

--- a/Teensy/src/gpio/gpio.cpp
+++ b/Teensy/src/gpio/gpio.cpp
@@ -105,7 +105,8 @@ static daq_BatteryV_t gpio_getVBat()
 {
     float batteryAnalogIn = analogRead(BATTERY_SENSOR_PIN);
     // the formula for 2 resistors connected in series, forming the voltage divider is: V1 = Vm * (R2/(R1+R2))
-    float batteryVoltage_dV = ((batteryAnalogIn / ADC_MAX_VALUE) * ADC_MAX_VOLTAGE) * BATTERY_SCALAR;
+    daq_BatteryV_t batteryVoltage_dV = (daq_BatteryV_t) ((batteryAnalogIn /
+    ADC_MAX_VALUE) * ADC_MAX_VOLTAGE) * BATTERY_SCALAR * 10;
     
     return batteryVoltage_dV;
 }

--- a/cmn/daq_common.h
+++ b/cmn/daq_common.h
@@ -8,7 +8,7 @@ typedef int32_t daq_DamperPos_t;
 typedef int32_t daq_GearPos_t;
 typedef int32_t daq_SteeringWhlPos_t;
 typedef int32_t daq_Strain_t;
-typedef float daq_BatteryV_t;
+typedef uint32_t daq_BatteryV_t;
 typedef int32_t daq_ThrottlePos_t;
 typedef int32_t daq_FuelPressure_t;
 

--- a/cmn/daq_common.h
+++ b/cmn/daq_common.h
@@ -8,7 +8,7 @@ typedef int32_t daq_DamperPos_t;
 typedef int32_t daq_GearPos_t;
 typedef int32_t daq_SteeringWhlPos_t;
 typedef int32_t daq_Strain_t;
-typedef int32_t daq_BatteryV_t;
+typedef float daq_BatteryV_t;
 typedef int32_t daq_ThrottlePos_t;
 typedef int32_t daq_FuelPressure_t;
 


### PR DESCRIPTION
unsure of how to error handle yet so it currently returns 100 when A16 is NULL.

Otherwise, the code should succesfully convert pin A16's data to the actual battery voltage in decivolts