### PR TITLE
GPS-reading using Adafruit_GPS module implemented

### DIFF
--- a/Teensy/src/gpio/gpio.cpp
+++ b/Teensy/src/gpio/gpio.cpp
@@ -9,12 +9,16 @@
  */
 
 #include <Arduino.h>
+#include <Adafruit_GPS.h>
 #include "gpio.h"
 #define SIZE_OF_CIRCLE_ARRAY 10
 #define REV_SENSOR_PIN 23
 #define BATTERY_SENSOR_PIN A16
+#define GPS_RX_PIN RX2
+#define GPS_TX_PIN TX2
 
 static WheelSpeed_s gpio_getWheelSpeed();
+static daq_GPSVehicleSpeed_t gpio_getGPSVehicleSpeed();
 static daq_EngineRev_t gpio_getEngineRevs();
 static DamperPos_S gpio_getDamperPosition();
 static daq_GearPos_t gpio_getGearPosition();
@@ -53,10 +57,40 @@ bool updateSensorInfo(sensorData_s *pSensorData)
     return false;
 }
 
+
 static WheelSpeed_s gpio_getWheelSpeed()
 {
     WheelSpeed_s wheelSpeed = {};
     return wheelSpeed;
+}
+
+    // setup for GPS readings
+    SoftwareSerial mySerial(GPS_RX_PIN, GPS_TX_PIN);
+    Adafruit_GPS GPS(&mySerial);
+    // connect at 115200 so we can read the GPS fast enough and echo without dropping chars
+    Serial.begin(115200);
+    delay(5000);
+    // 9600 NMEA is the default baud rate for Adafruit MTK GPS's- this may need to be changed to 4800 if it doesn't work
+    GPS.begin(9600);
+    GPS.sendCommand(PMTK_SET_NMEA_OUTPUT_RMCGGA);
+    // Set the update rate
+    GPS.sendCommand(PMTK_SET_NMEA_UPDATE_1HZ);   // 1 Hz update rate
+    // delay of 1 second
+    delay(1000);
+
+static daq_GPSVehicleSpeed_t gpio_getGPSVehicleSpeed()
+{
+    char c = GPS.read();
+    if ((c) && (GPSECHO))
+        Serial.write(c);
+
+    // if a sentence is received, we can check the checksum, parse it...
+    if (GPS.newNMEAreceived()) {
+        if (!GPS.parse(GPS.lastNMEA()))   // this also sets the newNMEAreceived() flag to false
+        return;  // we can fail to parse a sentence in which case we should just wait for another
+    }
+    daq_GPSVehicleSpeed_t vehicleSpeed = GPS.speed;
+    return vehicleSpeed;
 }
 
 static daq_EngineRev_t gpio_getEngineRevs()

--- a/cmn/daq_common.h
+++ b/cmn/daq_common.h
@@ -11,7 +11,7 @@ typedef int32_t daq_Strain_t;
 typedef uint32_t daq_BatteryV_t;
 typedef int32_t daq_ThrottlePos_t;
 typedef int32_t daq_FuelPressure_t;
-typedef int32_t daq_GPSVehicleSpeed_t;
+typedef float32_t daq_GPSVehicleSpeed_t;
 
 typedef struct WheelSpeed_s
 {

--- a/cmn/daq_common.h
+++ b/cmn/daq_common.h
@@ -11,6 +11,7 @@ typedef int32_t daq_Strain_t;
 typedef uint32_t daq_BatteryV_t;
 typedef int32_t daq_ThrottlePos_t;
 typedef int32_t daq_FuelPressure_t;
+typedef int32_t daq_GPSVehicleSpeed_t;
 
 typedef struct WheelSpeed_s
 {
@@ -54,6 +55,8 @@ typedef struct sensorData_s
   daq_ThrottlePos_t throttlePos_mm;
   // fuel pressure in pascals?
   daq_FuelPressure_t fuelPressure_pa;
+  // vehicle speed using GPS
+  daq_GPSVehicleSpeed_t GPSVehicleSpeed;
   // program run time
   uint32_t time_ms;
 } sensorData_s;


### PR DESCRIPTION
note that 9600 NMEA is the default baud rate for Adafruit MTK GPS's- this may need to be changed to 4800 if it doesn't work

There is other data that can be extracted from the GPS if needed. Only speed was included in this scenario.

New pins were defined as GPS_RX_PIN and GPS_TX_PIN.

Used this guy's [LCD screen display project](https://www.elithecomputerguy.com/2020/06/arduino-gps-adafruit-ultimate-gps-coordinates-and-speed-display-on-lcd/) as heavy inspiration.